### PR TITLE
chore:add-github-img

### DIFF
--- a/command.html
+++ b/command.html
@@ -9,6 +9,7 @@
     <body>
         <!-- Cabeçalho -->
         <header>
+            <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png" alt="logotipo Github, um círculo preto com a silhueta de um gato no centro" style="height:300px;width:300px;" />
             <h1>Git e GitHub</h1>
             <p>Um guia de comandos simplificado</p>
         </header>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <header>
+        <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png" alt="logotipo Github, um círculo preto com a silhueta de um gato no centro" style="height:300px;width:300px;" />
         <h2>Guia Git e Github - Boas Práticas</h2>
         <p>Esse guia está sendo desenvolvido pela <strong>Equipe 10</strong> da turma Turing.</p>
         <p>Esse projeto foi proposto pelo Professor <strong>Vitor</strong> e todos requisitos podem ser acessado <a href="https://alluring-beluga-3dd.notion.site/Projeto-site-HTML-git-Turing-f5636a96cbf9445fb53f810d88831fbf" target="_blank">aqui</a></p>


### PR DESCRIPTION
Added a img tag in the beginning of the header for all current merged pages, containing the github logo.