### PR TITLE
change page titles

### DIFF
--- a/command.html
+++ b/command.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
     <head>
         <meta charset="UTF-8">
-        <title>Git e Github</title>
+        <title>Guia Git e Github - Comandos</title>
 
         <link rel="stylesheet" href="./css/style.css">
     </head>
@@ -177,8 +177,8 @@
         </section>
 
         <footer>
-            Eu sou <strong>Janaína Scher</strong> e modifiquei essa página no dia <strong>09/05/2022 19:45</strong>. Caso você tenha modificado essa página atualize com seu nome,data e hora. <br/>
-            <strong>Obs. Em caso de conflito sempre opte pela a modificação mais recente.</strong>
+            Eu sou <strong>Fábio César</strong> e modifiquei essa página no dia <strong>11/05/2022 18:05</strong>. Caso você tenha modificado essa página atualize com seu nome,data e hora. <br/>
+            <strong>Obs. Em caso de conflito sempre opte pela modificação mais recente.</strong>
         </footer>
 
     </body>

--- a/equipe.html
+++ b/equipe.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="Isadora Guerra" />
     <meta name="description" content="Essa página contém informações sobre os integrantes da equipe." />
-    <title>Equipe 10</title>
+    <title>Guia Git e Github - Equipe 10</title>
     <link rel="stylesheet" href="./css/style.css">
 </head>
 
@@ -58,7 +58,7 @@
         </section>
     </main>
     <footer>
-        Eu sou <strong>Fábio César</strong> e modifiquei essa página no dia <strong>11/05/2022 17:45</strong>. Caso você tenha modificado essa página atualize com seu nome,data e hora. <br/>
+        Eu sou <strong>Fábio César</strong> e modifiquei essa página no dia <strong>11/05/2022 18:05</strong>. Caso você tenha modificado essa página atualize com seu nome,data e hora. <br/>
         <strong>Obs. Em caso de conflito sempre opte pela modificação mais recente.</strong>
     </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Guia Git e Github - Boas Práticas</title>
+    <title>Guia Git e Github</title>
     <link rel="stylesheet" href="./css/style.css">
 </head>
 <body>
@@ -22,8 +22,8 @@
         </ul>
     </nav>
     <footer>
-        Eu sou <strong>Diego Oliveira</strong> e modifiquei essa página no dia <strong>04/05/2022 17:54</strong>. Caso você tenha modificado essa página atualize com seu nome,data e hora. <br/>
-        <strong>Obs. Em caso de conflito sempre opte pela a modificação mais recente.</strong>
+        Eu sou <strong>Fábio César</strong> e modifiquei essa página no dia <strong>11/05/2022 18:05</strong>. Caso você tenha modificado essa página atualize com seu nome,data e hora. <br/>
+        <strong>Obs. Em caso de conflito sempre opte pela modificação mais recente.</strong>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
I gave the three pages &lt;title&gt; tags a standard to follow:
Index = Guia Git e Github, with each page adding its description to this global name.